### PR TITLE
Update Heroku Production URL

### DIFF
--- a/src/apiConfig.js
+++ b/src/apiConfig.js
@@ -1,6 +1,6 @@
 let apiUrl
 const apiUrls = {
-  production: 'https://guarded-anchorage-66706.herokuapp.com',
+  production: 'https://floating-eyrie-47940.herokuapp.com',
   development: 'http://localhost:4741'
 }
 


### PR DESCRIPTION
Update Heroku to new Atlas cluster due to removal of mlab support for mongoDB.